### PR TITLE
docs: declare the PR-gated remote - Phase 1 of the branching cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,12 @@ the preference is to land promptly, not defer. A few specifics:
   rule is the "Out-of-scope findings" section of [CLAUDE.md](CLAUDE.md).
 - **Ask first only for the hard-to-reverse / outward-facing** — pushing, tagging, a
   release, history rewrites. A local commit on `master` is none of those.
+- **The GitHub remote is PR-gated** (since 2026-06-10): a non-maintainer change
+  lands via PR with the `ci-ok` check green; merges are rebase/squash only
+  (linear history). Maintainer/fleet commits to local `master` are unchanged
+  during the transition (admin bypass). PR-path work uses a
+  `lane/<lane>/<slug>` branch in its own worktree — never switch the shared
+  working tree's branch while another loop is editing it.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,21 @@ Match the existing commit-subject grammar (see `git log`). Do **not** add a
 agent co-authors on commits, and this overrides any harness default that
 appends one.
 
+**The remote is PR-gated (Phase 1 of the branching cutover, 2026-06-10).**
+`master` on GitHub is branch-protected. For anyone but the maintainer, the
+way in is a PR with a green `ci-ok` check — the one required check; it folds
+the whole CI matrix into a single verdict. Merges are rebase or squash only
+(linear history; merge commits are off). Release tags (`v*`, `stable/*`)
+cannot be moved or deleted (a tag ruleset; admins keep a recovery bypass).
+The maintainer and this machine's fleet ride the admin bypass for now, so the
+local direct-commit-to-`master` ritual above is unchanged during the
+transition. PR-path work takes a `lane/<lane>/<slug>` branch in its **own
+worktree** (`git worktree add` — never switch the shared tree's branch under
+a concurrent loop); the branch name mirrors the arbiter's lane claim. The
+full cutover plan and the remaining steps (fleet + release-skill conversion,
+bypass removal) live in the private sibling repo,
+`notes/2026-06-10_branching-model-plan.md`.
+
 ### Out-of-scope findings — file an issue, don't widen the lane
 
 Working in here you will notice things that need doing but are not your task —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,26 @@ For the MCP server surface: `pip install -e ".[mcp]"` then `dos-mcp`.
 purpose; the suite is fast. A change that can't keep the suite green is a change that
 isn't ready.
 
+## Branching & merging
+
+`master` is the only long-lived branch, and it is protected:
+
+- **Changes land via pull request.** Direct pushes are reserved to the
+  maintainer (a transitional state); the contributor path is fork → branch → PR.
+- **One required check: `ci-ok`.** It folds the whole CI matrix (leak scan, lint,
+  the test legs, the wheel build) into a single verdict. The PR can merge when it
+  is green; no approving-review count is configured today (single-maintainer
+  reality — see "Maintenance reality" below).
+- **Rebase or squash only.** Merge commits are disabled and linear history is
+  enforced. A single-commit PR keeps its authored subject on squash, so write
+  the subject to the repo's grammar (`git log` shows it).
+- **Branch naming:** `lane/<lane>/<slug>` (e.g. `lane/docs/fix-readme-link`) is
+  the house style — `<lane>` mirrors the top-level directory the change touches,
+  the same taxonomy `dos arbitrate` adjudicates. Helpful but not enforced for
+  external PRs.
+- **Release tags are immutable** (`v*` and `stable/*`, by ruleset), and head
+  branches auto-delete on merge.
+
 ## What makes a good change
 
 - **Small, in one layer.** A PR that edits the kernel *and* a driver *and* a skill is


### PR DESCRIPTION
Phase 1 of the branching-model cutover (plan: the private repo's notes/2026-06-10_branching-model-plan.md).

Platform changes already live (this PR documents them):
- master branch protection: PR + green **ci-ok** required for non-maintainers, linear history, no force-push/delete; maintainer + local fleet on the transitional admin bypass
- merge methods: rebase + squash only, merge commits disabled, head branches auto-delete
- tag ruleset: v* and stable/* immutable (admin bypass for recovery)
- ci.yml: the ci-ok fold job - the one stable required-check context under the docs-aware matrix

This PR is itself the smoke test of the new path: lane branch in an isolated worktree, auto-merge on green ci-ok, rebase merge.