### PR TITLE
feat(hook): the enforcement posture — ASK escalates a refusal to the human, not just block (docs/370)

### DIFF
--- a/docs/370_permission-controlled-posture-ask-and-the-human-in-the-loop.md
+++ b/docs/370_permission-controlled-posture-ask-and-the-human-in-the-loop.md
@@ -1,0 +1,200 @@
+# 370 — The permission-controlled posture: ASK and the human in the loop
+
+> **Status:** Phase 1 SHIPPED (the `ASK` action + the `Posture` seam +
+> Claude-Code-family native rendering). The roadmap phases (§6) are numbered,
+> each a litmus-checkable unit. Implementation: `hook_dialect.HookAction.ASK`,
+> `hook_dialect.Posture` / `parse_posture` / `under_posture`,
+> `cli._hook_posture`, `tests/test_hook_ask_posture.py`.
+
+## The wound, stated once
+
+DOS grew up in one deployment: the **headless, bypass-permissions fleet**. An
+autonomous loop runs with the host's permission prompts turned off
+(`--dangerously-skip-permissions`, YOLO mode, full-auto). There is no human at
+the keyboard. In that world DOS is the *only* gate, so the only useful thing a
+hook can do is **block** a bad call or **stay silent**. The whole hook protocol
+reflects that: the dialect-neutral verdict had exactly three actions —
+
+```
+DENY   — withhold the call
+WARN   — add context, do not block
+PASS   — emit nothing
+```
+
+But most of the industry does **not** run headless bypass. The default Claude
+Code session asks the human before each edit. Cursor, Codex, and Gemini all
+ship an approval mode. Enterprises run least-privilege allowlists with a human
+approver on anything outside them. For those users — the ones who want *more*
+control, not less — DOS had a relevance gap:
+
+- **The protocol could not ROUTE a call to the human.** Claude Code's own
+  permission verb set is `z.enum(['allow','deny','ask'])`. DOS only ever emitted
+  `deny`. It could block, but it could not say "I'm not certain — *you* decide,"
+  which is the single most common thing a human-in-the-loop operator wants from
+  a referee. DOS could *replace* the human's judgment (block) or *abstain*
+  (stay silent); it could not *inform* it.
+- **The default posture was written for the loop.** docs/364 made BLOCK the
+  default for loop sessions — correct for headless, where a block is the only
+  safety net. But the control-oriented operator does not want a hard block from
+  a referee; they want the referee's finding handed to *them* at the prompt they
+  already answer.
+- **The UX was operator-PULL.** `dos doctor`, `dos decisions`, the enforce
+  journal — all are surfaces the operator runs a command to read. Nothing PUSHED
+  an adjudicated fact to the human *at the moment they were deciding*.
+
+The fix is not a new subsystem. It is one new action and one new seam, both
+small, both pure, that let DOS **participate in** a host's permission flow
+instead of replacing it.
+
+## 1. ASK — the missing action
+
+`HookAction.ASK`: escalate a refusal to the human's permission prompt. DOS does
+not decide for the human; it hands them a reason **the agent could not have
+authored** (a git fact, a lane collision, a minted-id finding) and lets them
+answer with the host's existing allow/deny UI.
+
+ASK is the byte-author axiom (docs/138, ZERO_TRUST.md) applied to the human
+seam: the agent narrates "this is fine"; DOS does not believe it and does not
+overrule the human either — it surfaces the adjudicated fact and routes the
+decision to the one party with the authority to make it. The ORACLE → JUDGE →
+HUMAN escalation ladder (the breaker's stalemate rungs, ZERO_TRUST.md pillar 5)
+finally has a *mechanism* at the hook surface: ASK **is** the HUMAN rung,
+delivered inline.
+
+Where ASK renders natively (verified against the host's gate):
+
+| Host | ASK grammar | Verified |
+|---|---|---|
+| Claude Code | `permissionDecision: "ask"` | CC source `permissionBehaviorSchema = z.enum(['allow','deny','ask'])` |
+| Codex CLI | CC-identical envelope → `ask` | delegates to the CC renderer (docs/217) |
+| Claude Cowork | runs the CC harness → `ask` | delegates to the CC renderer (docs/298) |
+
+Where it does **not** yet render natively (Gemini / Cursor / Antigravity /
+Hermes), ASK degrades to a **turn-preserving WARN** — a non-blocking surface
+that names the finding but does not pause. This is the honest-coverage
+discipline the seam already holds for every host gap (Hermes' WARN→`{}`,
+docs/278; Trae's deliberate absence, docs/294): DOS never fabricates a host
+grammar it has not verified, and an ASK never silently hard-blocks (that would
+contradict the operator's choice to keep the human in the loop). Native
+per-host ASK is §6 Phase A.
+
+The fail-open dual is pinned: an ASK must carry **no** hard-deny signal on any
+host (`tests/test_hook_ask_posture.py::test_non_cc_hosts_degrade_ask_to_a_non_blocking_surface`),
+the ASK analogue of the docs/268 deny-must-block floor.
+
+## 2. The posture seam — observe / block / gate
+
+The operator declares ONE choice — how a refusal is **surfaced** — and the same
+adjudicated verdict renders three ways:
+
+| Posture | A refusal becomes | For whom |
+|---|---|---|
+| `observe` | a turn-preserving WARN (records, never blocks, never prompts) | the cautious first-adopter; the pre-docs/364 behavior, now an explicit choice |
+| `block` | a hard DENY | the **headless / bypass-permissions** fleet — DOS is the gate. **The default.** Byte-for-byte today's behavior. |
+| `gate` | an **ASK** at the human's permission prompt | the **control-oriented / human-in-the-loop** operator |
+
+The posture is **monotone-softening**: `under_posture` only ever re-shapes a
+DENY into a *softer* surface (ASK or WARN). It never hardens a PASS/WARN into a
+block, and never turns an admit into a refusal. This is the refuse-equal-or-
+softer dual of the overlap policy's refuse-MORE-only floor (CLAUDE.md litmus):
+a posture is a rendering choice the operator owns, structurally incapable of
+manufacturing a refusal the verdict did not already contain.
+
+Selection (boundary read, `cli._hook_posture`, precedence):
+
+1. `DOS_HOOK_POSTURE` env — a fleet-wide override, read per-call like
+   `DOS_APPLY_GATE` (the docs/364 cut-the-gate precedent: no restart, the env is
+   read on every hook event).
+2. `dos.toml [enforcement] posture` — the per-workspace declaration.
+3. the `block` default — so an operator who sets nothing sees no change.
+
+An unknown posture name degrades to `block` (the safe, behavior-preserving
+direction) — unlike a dialect typo, which fails LOUD. The asymmetry is
+deliberate: a wrong dialect is a silent no-op against a real host (must surface);
+a wrong posture can only ever make DOS *stricter*, never drop a gate, so the
+safe default is correct and `dos doctor` surfaces the effective posture.
+
+## 3. How GATE composes with the existing softening
+
+`decide()` already softens many denies to WARN for an **interactive operator**
+(no loop env — docs/355 for SELF_MODIFY, docs/126/143 for a lane collision). The
+posture composes cleanly with that, because the two answer different questions:
+
+- The operator-session softening asks *"is a human already in command of this
+  session?"* If yes, their own deliberate edit is theirs to make → WARN.
+- The posture asks *"how should a refusal that survives be surfaced?"*
+
+So a **loop** session under `gate` posture turns its hard denies into ASKs (the
+human gets the gate the loop cannot answer for itself), while an **interactive**
+operator keeps their advisory WARN (they *are* the human). The two are not in
+tension — GATE is most load-bearing exactly where the softening does *not* fire:
+the automated session that needs a human's call.
+
+## 4. Why this stays kernel-clean
+
+- `HookAction.ASK`, `Posture`, `parse_posture`, `under_posture` are PURE and
+  name no host (an env name and a closed enum, like `DOS_APPLY_GATE`). The
+  vendor-blind litmus (`test_vendor_agnostic_kernel.py`) is untouched.
+- Native ASK *rendering* lives where every renderer lives: the unshadowable
+  `ClaudeCodeDialect` default in the kernel seam, and the per-vendor renderers in
+  the `drivers/hook_dialects` driver (docs/217). A host's ask grammar is OUTPUT,
+  downstream of an already-decided verdict — driver territory, not a decision.
+- The transform is applied at the CLI rendering boundary
+  (`parse_cc → under_posture → render`), so `decide()` and its 67 green hook
+  tests are untouched, and `--dialect claude-code` + default posture is
+  byte-for-byte today's bytes (the docs/217 Phase-1 parity floor, re-pinned
+  here for the posture: `test_real_deny_under_block_stays_a_deny`).
+
+## 5. The litmus tests this seam must satisfy
+
+1. **ASK never hard-blocks.** On every host, an ASK carries no deny signal —
+   it escalates, it does not block. (The fail-open dual.)
+2. **Posture is monotone-softening.** `under_posture` re-shapes only a DENY,
+   only ever softer; a PASS/WARN/ASK is returned unchanged under every posture.
+3. **The default is parity.** Unset posture == `block` == today's bytes.
+4. **GATE is PRE-only.** "Ask the human" is meaningful only before a tool runs;
+   a Stop/Post refusal under GATE stays a DENY (no permission-prompt seam to
+   escalate into — never a fabricated ask).
+5. **The kernel names no host in the posture seam.**
+
+## 6. The roadmap — what 98% coverage of the control-oriented world still needs
+
+Each is a numbered, litmus-checkable follow-up; none is a kernel-architecture
+change.
+
+- **Phase A — native per-host ASK.** Verify each non-CC host's "ask the human"
+  grammar (Cursor's `permission: "ask"`, Gemini's confirm path, Antigravity's
+  decision vocabulary) against the real runtime, then render natively instead of
+  degrading to WARN. Same web-grounded discipline as docs/268/278. → a GitHub
+  issue per host, gated on a verified probe.
+- **Phase B — `HookAction.ALLOW` + the `assist` posture (the verified
+  allowlist).** In a permission-on deployment the human is prompted constantly.
+  DOS holds facts they do not (this read is in-lane, this write is contained,
+  this is a no-footprint tool). `assist` = GATE + auto-`allow` of the calls DOS
+  has *positively verified* safe, so the human is prompted only for the genuinely
+  uncertain ones — a verified allowlist, not a static one. ALLOW must be strictly
+  opt-in and refuse-narrow (auto-allow only what is provably safe; everything
+  else still asks).
+- **Phase C — posture-aware observation.** `hook_observation` /
+  `dos doctor` should report *escalated-to-human* vs *hard-blocked* counts, so
+  the operator sees how often DOS hands them a call. Today the journal records
+  the kernel verdict (deny); the surface action (ask) is rendering-only.
+- **Phase D — the decision-inbox round-trip.** An ASK the human DEFERS becomes a
+  `decisions` row (the HUMAN resolver kind already exists, `decisions.py`), so a
+  deferred escalation is not lost — it lands in the `dos decisions` queue.
+- **Phase E — `dos init --posture gate`.** Wire the control-oriented default at
+  install time and document the interplay with the host's OWN permission
+  settings (DOS `gate` + the host's allowlist are complementary: the allowlist
+  handles the routine, DOS escalates the adjudicated exceptions).
+- **Phase F — Go fast-path parity.** The native `dos-hook` binary serves the
+  default BLOCK path; the posture transform is Python-side today. Carry the
+  posture into the Go decider so a gated fleet keeps the fast path. (Default
+  BLOCK already has Go parity — only `gate`/`observe` need the Python path now.)
+
+## 7. The one-line frame
+
+DOS was the referee for the room with no human in it. The posture seam makes it
+the referee for the room *with* one — not by deciding for the human, but by
+handing them the one fact the agent could not forge, at the moment they decide.
+
+## Fixes (none yet — opens the Phase A–F issues above)

--- a/src/dos/cli.py
+++ b/src/dos/cli.py
@@ -5571,6 +5571,27 @@ def cmd_hook_posttool(args: argparse.Namespace) -> int:
     return 0
 
 
+def _hook_posture(cfg) -> "object":
+    """The operator's declared enforcement POSTURE for this workspace (docs/370).
+
+    Boundary read — the one I/O behind the pure `hook_dialect.under_posture`. Precedence:
+    the `DOS_HOOK_POSTURE` env (a fleet-wide override, read per-call like
+    `DOS_APPLY_GATE`), then `dos.toml [enforcement] posture`, then the BLOCK default.
+    Any shape miss degrades to the default (which `parse_posture` also enforces), so a
+    malformed config never breaks the hook hot path. Returns a `hook_dialect.Posture`.
+    """
+    from dos import hook_dialect as _hd
+    name = os.environ.get("DOS_HOOK_POSTURE", "").strip()
+    if not name:
+        try:
+            table = _config._load_toml_table(Path(cfg.root) / "dos.toml", "enforcement")
+            if isinstance(table, dict):
+                name = str(table.get("posture") or "").strip()
+        except Exception:  # noqa: BLE001 — a torn/absent config never breaks the hook
+            name = ""
+    return _hd.parse_posture(name)
+
+
 def cmd_hook_pretool(args: argparse.Namespace) -> int:
     """A `PreToolUse` hook: DENY a structurally-refused tool call BEFORE it runs (docs/191).
 
@@ -5674,6 +5695,12 @@ def cmd_hook_pretool(args: argparse.Namespace) -> int:
             from dos import hook_dialect as _hd
             renderer = _hd.resolve_dialect(getattr(args, "dialect", None))
             verdict = _hd.parse_cc(dialect, moment=_hd.HookMoment.PRE)
+            # docs/370 — the enforcement POSTURE: an operator who keeps a human in
+            # the loop sets `gate` to ESCALATE a refusal to their permission prompt
+            # (an ASK) instead of a hard block; `observe` records only. Default BLOCK
+            # is byte-for-byte today's behavior (the parity floor). The transform is
+            # pure; the env/config read is the one boundary line here.
+            verdict = _hd.under_posture(verdict, _hook_posture(cfg))
             host_dialect = renderer.render(verdict)
         except ValueError as exc:  # unknown dialect name — surface, do not guess a host
             _dbg(f"dialect error ({exc}) — emitting nothing (passthrough)")

--- a/src/dos/hook_dialect.py
+++ b/src/dos/hook_dialect.py
@@ -78,6 +78,7 @@ class HookAction(enum.Enum):
     """The dialect-neutral decision. Maps 1:1 onto every host's grammar."""
 
     DENY = "deny"  # withhold the call / refuse the stop
+    ASK = "ask"    # escalate to the human's permission prompt (do NOT decide for them)
     WARN = "warn"  # add context, do NOT block (turn-preserving)
     PASS = "pass"  # emit nothing
 
@@ -96,6 +97,94 @@ class HookVerdict:
     action: HookAction
     reason: str = ""
     context: str = ""
+
+
+# ---------------------------------------------------------------------------
+# The enforcement POSTURE — how a refusal is SURFACED (docs/370). The kernel
+# computes ONE verdict; the operator picks whether a refusal hard-blocks, asks
+# the human, or merely records. PURE: a posture only ever RE-SHAPES a refusal
+# (DENY) into a softer surface; it never hardens a PASS/WARN into a block, and
+# never turns an admit into a deny. So a posture is monotone-softening — the
+# refuse-equal-or-softer dual of the overlap policy's refuse-MORE-only floor.
+#
+# DOS shipped assuming the headless / bypass-permissions deployment, where DOS
+# is the ONLY gate, so a refusal must BLOCK. The control-oriented deployment
+# keeps a human in the loop and wants DOS to ESCALATE to that human's existing
+# permission prompt instead of deciding for them. The posture is that choice.
+# ---------------------------------------------------------------------------
+class Posture(enum.Enum):
+    """How the host surfaces a DOS refusal. Selected by the operator, never by an agent.
+
+      OBSERVE — record only. A refusal degrades to a turn-preserving WARN: DOS
+                names the violation but never blocks and never prompts. The
+                cautious first-adopter posture (the pre-docs/364 behavior, now an
+                explicit choice).
+      BLOCK   — a refusal hard-DENYs the call. DOS is the gate. The headless /
+                bypass-permissions default — byte-for-byte today's behavior, so an
+                operator who sets nothing sees no change (the parity floor).
+      GATE    — a refusal ESCALATES to the human's permission prompt (an ASK at the
+                PRE moment). DOS does not decide for the human; it hands them an
+                adjudicated reason the agent could not have authored. The
+                control-oriented / human-in-the-loop posture.
+    """
+
+    OBSERVE = "observe"
+    BLOCK = "block"
+    GATE = "gate"
+
+
+#: The default — BLOCK, so an operator who declares no posture gets exactly the
+#: bytes DOS has emitted since the hooks shipped (the docs/370 parity floor).
+DEFAULT_POSTURE = Posture.BLOCK
+
+
+def parse_posture(name: Optional[str]) -> Posture:
+    """Resolve a posture name to a `Posture`. PURE. Lenient → `DEFAULT_POSTURE`.
+
+    Unlike `resolve_dialect` (fail-LOUD), an unknown / empty posture name falls
+    back to BLOCK — the SAFE direction (more restrictive than GATE/OBSERVE), and
+    the one that preserves today's bytes. A typo can only ever make DOS *stricter*,
+    never silently drop a gate; `dos doctor` surfaces the effective posture so the
+    typo is visible without breaking the hook hot path.
+    """
+    if not name:
+        return DEFAULT_POSTURE
+    try:
+        return Posture(str(name).strip().lower())
+    except ValueError:
+        return DEFAULT_POSTURE
+
+
+def under_posture(verdict: HookVerdict, posture: Posture) -> HookVerdict:
+    """Re-shape a verdict's SURFACE for the operator's posture. PURE, total.
+
+    Only a DENY is ever re-shaped (a PASS/WARN/ASK passes through untouched — a
+    posture never hardens). The mapping:
+
+      * BLOCK   → unchanged (a DENY stays a DENY — today's behavior).
+      * OBSERVE → a DENY becomes a WARN; the refusal's `reason` is folded into the
+                  `context` so the human still reads WHY, but nothing blocks.
+      * GATE    → a PRE-moment DENY becomes an ASK (route to the human's permission
+                  prompt). A non-PRE DENY (a Stop refusal, a Post context) stays a
+                  DENY: "ask the human" is meaningful only BEFORE a tool runs — a
+                  stop has no permission-prompt seam to escalate into, so GATE leaves
+                  it a block (the honest-coverage direction, never a fabricated ask).
+
+    The transform is the keystone that lets DOS PARTICIPATE in a host's permission
+    flow rather than replace it: the same adjudicated verdict, surfaced as the
+    operator chose.
+    """
+    if verdict.action is not HookAction.DENY:
+        return verdict
+    if posture is Posture.OBSERVE:
+        merged = " ".join(p for p in (verdict.reason, verdict.context) if p).strip()
+        return HookVerdict(moment=verdict.moment, action=HookAction.WARN, context=merged)
+    if posture is Posture.GATE and verdict.moment is HookMoment.PRE:
+        return HookVerdict(
+            moment=verdict.moment, action=HookAction.ASK,
+            reason=verdict.reason, context=verdict.context,
+        )
+    return verdict
 
 
 # ---------------------------------------------------------------------------
@@ -118,10 +207,11 @@ def parse_cc(cc_dict: Optional[dict], *, moment: HookMoment) -> HookVerdict:
     decision = hso.get("permissionDecision")
     context = hso.get("additionalContext")
     context = context if isinstance(context, str) else ""
-    if decision == "deny":
+    if decision in ("deny", "ask"):
         reason = hso.get("permissionDecisionReason")
         reason = reason if isinstance(reason, str) else ""
-        return HookVerdict(moment=moment, action=HookAction.DENY, reason=reason, context=context)
+        act = HookAction.DENY if decision == "deny" else HookAction.ASK
+        return HookVerdict(moment=moment, action=act, reason=reason, context=context)
     if context:
         # additionalContext present, no deny → a WARN (turn-preserving re-surface).
         return HookVerdict(moment=moment, action=HookAction.WARN, context=context)
@@ -164,10 +254,15 @@ class ClaudeCodeDialect:
         if verdict.action is HookAction.PASS:
             return None
         event = _CC_EVENT[verdict.moment]
-        if verdict.action is HookAction.DENY:
+        if verdict.action in (HookAction.DENY, HookAction.ASK):
+            # `deny` withholds the call; `ask` routes it to the human's permission
+            # prompt — both are the `permissionDecision` gate CC honors
+            # (`z.enum(['allow','deny','ask'])`, verified against the CC source). The
+            # only field that differs is the verb; the why + corrective ride the same
+            # `permissionDecisionReason` / `additionalContext` channels.
             hso = {
                 "hookEventName": event,
-                "permissionDecision": "deny",
+                "permissionDecision": "deny" if verdict.action is HookAction.DENY else "ask",
                 "permissionDecisionReason": verdict.reason,
             }
             if verdict.context:

--- a/tests/test_hook_ask_posture.py
+++ b/tests/test_hook_ask_posture.py
@@ -1,0 +1,289 @@
+"""Tests for the enforcement POSTURE and the ASK action (docs/370).
+
+DOS shipped assuming the headless / bypass-permissions deployment: the hook
+vocabulary was DENY / WARN / PASS, so a refusal could only BLOCK or stay silent —
+it could not ROUTE a call into a human's permission prompt. docs/370 adds the
+`ASK` action and the `Posture` seam so DOS can *participate* in a host's permission
+flow instead of replacing it. This suite pins:
+
+  * **ASK renders to the host's "ask the human" grammar** — Claude Code's
+    `permissionDecision: "ask"` (verified `z.enum(['allow','deny','ask'])`), and the
+    CC-identical Codex / Claude-Cowork delegate to it. A host with no native ask
+    grammar degrades ASK to a turn-preserving WARN (honest coverage, never a
+    fabricated ask the host's gate ignores, never a hard block).
+  * **The posture is monotone-softening.** `under_posture` only ever re-shapes a
+    DENY into a softer surface (ASK or WARN); it never hardens a PASS/WARN/ASK, and
+    never invents a refusal. BLOCK (the default) is byte-for-byte today's behavior
+    (the parity floor).
+  * **GATE escalates at PRE only.** "ask the human" is meaningful before a tool
+    runs; a Stop/Post refusal under GATE stays a DENY (no permission-prompt seam to
+    escalate into).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dos import hook_dialect as hd
+from dos import pretool_sensor as prt
+
+
+# ---------------------------------------------------------------------------
+# parse_posture — lenient, fail-safe to the BLOCK default.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name,expected", [
+    ("observe", hd.Posture.OBSERVE),
+    ("block", hd.Posture.BLOCK),
+    ("gate", hd.Posture.GATE),
+    ("GATE", hd.Posture.GATE),
+    ("  Gate  ", hd.Posture.GATE),
+])
+def test_parse_posture_known_names(name, expected):
+    assert hd.parse_posture(name) is expected
+
+
+@pytest.mark.parametrize("bad", [None, "", "  ", "gat", "yolo", "deny", "allow", "42"])
+def test_parse_posture_unknown_falls_back_to_block(bad):
+    """Unlike resolve_dialect (fail-LOUD), an unknown posture degrades to the SAFE,
+    behavior-preserving BLOCK default — a typo can only make DOS stricter, never
+    silently drop a gate."""
+    assert hd.parse_posture(bad) is hd.Posture.BLOCK
+    assert hd.DEFAULT_POSTURE is hd.Posture.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# under_posture — the pure monotone-softening transform.
+# ---------------------------------------------------------------------------
+def _deny(moment=hd.HookMoment.PRE, context=""):
+    return hd.HookVerdict(moment=moment, action=hd.HookAction.DENY,
+                          reason="blocked by DOS", context=context)
+
+
+def test_block_leaves_a_deny_unchanged():
+    v = _deny()
+    assert hd.under_posture(v, hd.Posture.BLOCK) == v
+
+
+def test_gate_turns_a_pre_deny_into_an_ask():
+    out = hd.under_posture(_deny(context="read it first"), hd.Posture.GATE)
+    assert out.action is hd.HookAction.ASK
+    assert out.reason == "blocked by DOS"
+    assert out.context == "read it first"  # corrective preserved for the human
+
+
+@pytest.mark.parametrize("moment", [hd.HookMoment.POST, hd.HookMoment.STOP, hd.HookMoment.SESSION])
+def test_gate_leaves_a_non_pre_deny_a_deny(moment):
+    """'Ask the human' is a PRE-only seam — a Stop/Post refusal has no permission
+    prompt to escalate into, so GATE leaves it a block (never a fabricated ask)."""
+    out = hd.under_posture(_deny(moment=moment), hd.Posture.GATE)
+    assert out.action is hd.HookAction.DENY
+
+
+def test_observe_turns_a_deny_into_a_warn_folding_reason_into_context():
+    out = hd.under_posture(_deny(context="read it first"), hd.Posture.OBSERVE)
+    assert out.action is hd.HookAction.WARN
+    # The human still reads WHY — the reason is folded into the surviving context.
+    assert "blocked by DOS" in out.context
+    assert "read it first" in out.context
+
+
+@pytest.mark.parametrize("posture", list(hd.Posture))
+@pytest.mark.parametrize("action", [hd.HookAction.PASS, hd.HookAction.WARN, hd.HookAction.ASK])
+def test_posture_never_hardens_a_non_deny(posture, action):
+    """Monotone-softening: a posture only re-shapes a DENY. A PASS/WARN/ASK is
+    untouched under every posture — a posture can never invent a refusal."""
+    v = hd.HookVerdict(moment=hd.HookMoment.PRE, action=action, context="ctx")
+    assert hd.under_posture(v, posture) is v
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeDialect — native ASK render + parse_cc round-trip.
+# ---------------------------------------------------------------------------
+def test_claude_code_renders_ask_as_permission_decision_ask():
+    v = hd.HookVerdict(moment=hd.HookMoment.PRE, action=hd.HookAction.ASK,
+                       reason="escalated to you", context="read it first")
+    out = hd.resolve_dialect("claude-code").render(v)
+    assert out == {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "ask",
+        "permissionDecisionReason": "escalated to you",
+        "additionalContext": "read it first",
+    }}
+
+
+def test_parse_cc_reads_ask_back_to_the_ask_action():
+    cc = {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse", "permissionDecision": "ask",
+        "permissionDecisionReason": "escalated"}}
+    v = hd.parse_cc(cc, moment=hd.HookMoment.PRE)
+    assert v.action is hd.HookAction.ASK
+    assert v.reason == "escalated"
+
+
+def test_ask_round_trips_through_the_cc_dialect():
+    """render(parse_cc(d)) == d for an ask dict — the same Phase-1 round-trip floor
+    the deny/warn cases satisfy, extended to the new action."""
+    cc = hd.resolve_dialect("claude-code").render(
+        hd.HookVerdict(moment=hd.HookMoment.PRE, action=hd.HookAction.ASK,
+                       reason="r", context="c"))
+    back = hd.resolve_dialect("claude-code").render(hd.parse_cc(cc, moment=hd.HookMoment.PRE))
+    assert back == cc
+
+
+def test_ask_is_not_a_deny_blocking_signal():
+    """An ASK must NOT carry a hard-deny signal — it escalates, it does not block.
+    (The fail-open floor in test_hook_dialect.py guards DENY; this is its ASK dual:
+    an ask is a distinct, non-blocking permission verb.)"""
+    out = hd.resolve_dialect("claude-code").render(
+        hd.HookVerdict(moment=hd.HookMoment.PRE, action=hd.HookAction.ASK, reason="r"))
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert out["hookSpecificOutput"]["permissionDecision"] != "deny"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a real decide() deny, transcoded under each posture.
+# ---------------------------------------------------------------------------
+def _self_modify_deny_dict(tmp_path, monkeypatch):
+    """A real decide() SELF_MODIFY deny dict (the loop-session hard-deny path)."""
+    import dataclasses
+    from dos import config as _config
+    monkeypatch.setenv("DOS_LOOP", "1")  # docs/355 — reach the hard deny, not the operator WARN
+    cfg = _config.default_config(tmp_path)
+    facts = _config.WorkspaceFacts(
+        root=tmp_path,
+        kernel_runtime_files=("src/dos/arbiter.py",),
+        is_kernel_repo=True,
+    )
+    cfg = dataclasses.replace(cfg, workspace=facts)
+    event = {
+        "session_id": "t", "tool_name": "Write",
+        "tool_input": {"file_path": "src/dos/arbiter.py", "content": "x"},
+        "cwd": str(tmp_path),
+    }
+    cc_dict, outcome = prt.decide(event, cfg)
+    assert outcome["decision"] == "deny" and outcome["reason_class"] == "SELF_MODIFY"
+    return cc_dict
+
+
+def test_real_deny_under_block_stays_a_deny(tmp_path, monkeypatch):
+    cc = _self_modify_deny_dict(tmp_path, monkeypatch)
+    v = hd.under_posture(hd.parse_cc(cc, moment=hd.HookMoment.PRE), hd.Posture.BLOCK)
+    out = hd.resolve_dialect("claude-code").render(v)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_real_deny_under_gate_becomes_an_ask(tmp_path, monkeypatch):
+    """The keystone: a hard SELF_MODIFY deny, under the control-oriented GATE posture,
+    is handed to the human's permission prompt — same adjudicated reason, no block."""
+    cc = _self_modify_deny_dict(tmp_path, monkeypatch)
+    v = hd.under_posture(hd.parse_cc(cc, moment=hd.HookMoment.PRE), hd.Posture.GATE)
+    out = hd.resolve_dialect("claude-code").render(v)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "SELF_MODIFY" in out["hookSpecificOutput"]["permissionDecisionReason"] \
+        or "running" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_real_deny_under_observe_is_context_only_no_permission_decision(tmp_path, monkeypatch):
+    cc = _self_modify_deny_dict(tmp_path, monkeypatch)
+    v = hd.under_posture(hd.parse_cc(cc, moment=hd.HookMoment.PRE), hd.Posture.OBSERVE)
+    out = hd.resolve_dialect("claude-code").render(v)
+    hso = out["hookSpecificOutput"]
+    assert "permissionDecision" not in hso  # record-only: never blocks, never prompts
+    assert hso["additionalContext"]  # but the why is still surfaced
+
+
+# ---------------------------------------------------------------------------
+# _hook_posture — the boundary read (env precedence over config, default BLOCK).
+# ---------------------------------------------------------------------------
+def test_hook_posture_reads_env(tmp_path, monkeypatch):
+    from dos import cli as _cli
+    from dos import config as _config
+    cfg = _config.default_config(tmp_path)
+    monkeypatch.setenv("DOS_HOOK_POSTURE", "gate")
+    assert _cli._hook_posture(cfg) is hd.Posture.GATE
+    monkeypatch.setenv("DOS_HOOK_POSTURE", "observe")
+    assert _cli._hook_posture(cfg) is hd.Posture.OBSERVE
+
+
+def test_hook_posture_defaults_to_block_when_unset(tmp_path, monkeypatch):
+    from dos import cli as _cli
+    from dos import config as _config
+    monkeypatch.delenv("DOS_HOOK_POSTURE", raising=False)
+    cfg = _config.default_config(tmp_path)
+    assert _cli._hook_posture(cfg) is hd.Posture.BLOCK
+
+
+def test_hook_posture_reads_dos_toml_enforcement_section(tmp_path, monkeypatch):
+    from dos import cli as _cli
+    from dos import config as _config
+    monkeypatch.delenv("DOS_HOOK_POSTURE", raising=False)
+    (tmp_path / "dos.toml").write_text("[enforcement]\nposture = \"gate\"\n", encoding="utf-8")
+    cfg = _config.default_config(tmp_path)
+    assert _cli._hook_posture(cfg) is hd.Posture.GATE
+
+
+def test_env_posture_overrides_config(tmp_path, monkeypatch):
+    from dos import cli as _cli
+    from dos import config as _config
+    (tmp_path / "dos.toml").write_text("[enforcement]\nposture = \"observe\"\n", encoding="utf-8")
+    monkeypatch.setenv("DOS_HOOK_POSTURE", "block")
+    cfg = _config.default_config(tmp_path)
+    assert _cli._hook_posture(cfg) is hd.Posture.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Per-host ASK rendering — native on the CC family, honest WARN-degrade elsewhere.
+# (Skips if the dos.hook_dialects driver entry points aren't registered, mirroring
+# test_hook_dialect.py — `pip install -e .` registers them.)
+# ---------------------------------------------------------------------------
+_DRIVER_DIALECTS = ("codex", "gemini", "cursor", "antigravity", "hermes", "claude-cowork")
+_drivers_present = all(name in hd.available_dialects() for name in _DRIVER_DIALECTS)
+_needs_drivers = pytest.mark.skipif(
+    not _drivers_present,
+    reason="dos.hook_dialects driver entry points not registered (run `pip install -e .`)",
+)
+
+
+def _blocking_signal(out) -> str:
+    """The host-honored HARD-DENY signal in a rendered envelope, or "" if none.
+    (Copied from test_hook_dialect.py — an ASK must carry NONE of these.)"""
+    if not isinstance(out, dict):
+        return ""
+    if out.get("continue") is False:
+        return "continue:false"
+    inner = out.get("hookSpecificOutput")
+    if isinstance(inner, dict) and inner.get("permissionDecision") == "deny":
+        return "permissionDecision:deny"
+    if out.get("decision") in ("deny", "block"):
+        return f"decision:{out['decision']}"
+    if out.get("permission") == "deny":
+        return "permission:deny"
+    return ""
+
+
+def _ask_verdict():
+    return hd.HookVerdict(moment=hd.HookMoment.PRE, action=hd.HookAction.ASK,
+                          reason="escalated to you", context="")
+
+
+@_needs_drivers
+@pytest.mark.parametrize("name", ["codex", "claude-cowork"])
+def test_cc_family_renders_ask_natively(name):
+    """Codex and Claude-Cowork run/copy the CC harness, so an ASK renders identical
+    to the CC dialect's native `permissionDecision: "ask"`."""
+    v = _ask_verdict()
+    assert hd.resolve_dialect(name).render(v) == hd.resolve_dialect("claude-code").render(v)
+    assert hd.resolve_dialect(name).render(v)["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+@_needs_drivers
+@pytest.mark.parametrize("name", ["gemini", "cursor", "antigravity", "hermes"])
+def test_non_cc_hosts_degrade_ask_to_a_non_blocking_surface(name):
+    """A host with no verified native ask grammar degrades ASK to a turn-preserving
+    WARN surface: it MUST NOT hard-block (that would contradict the operator's GATE
+    choice) and MUST NOT fabricate an ask the host's gate ignores. Native per-host
+    ASK is the docs/370 roadmap follow-up; until each host's ask grammar is verified,
+    the honest degrade is a non-blocking surface."""
+    out = hd.resolve_dialect(name).render(_ask_verdict())
+    assert _blocking_signal(out) == "", (
+        f"ASK on {name!r} rendered a HARD-DENY signal {out!r} — GATE must not block")


### PR DESCRIPTION
## The gap

DOS grew up in the **headless / bypass-permissions** deployment, where it is the
*only* gate. So the hook vocabulary was `DENY / WARN / PASS` — it could block a
call or stay silent, but it could not **route a call into a human's permission
prompt**. Claude Code's own verb set is `z.enum(['allow','deny','ask'])`; DOS
only ever emitted `deny`. That left the **control-oriented / human-in-the-loop**
operator — most of the industry — under-served: DOS could replace their judgment
(block) or abstain (stay silent), but not *inform* it.

## What this ships (docs/370, Phase 1)

- **`HookAction.ASK`** — escalate a refusal to the human's permission prompt
  instead of hard-blocking. DOS hands the human a reason the agent could not have
  authored and lets them answer with the host's existing allow/deny UI. Native on
  the Claude Code family (`permissionDecision: "ask"`, verified against the CC
  source; Codex/Cowork delegate); honest non-blocking WARN-degrade on hosts whose
  ask grammar isn't yet verified (never a fabricated grammar, never a silent block).
- **The `Posture` seam** (`observe` / `block` / `gate`) selected via
  `DOS_HOOK_POSTURE` or `dos.toml [enforcement] posture`. `block` (default) is
  **byte-for-byte today's behavior** (the parity floor); `gate` is the
  control-oriented posture (refusals become `ask`); `observe` records only. The
  transform is pure and **monotone-softening** — it only ever re-shapes a DENY
  into a softer surface, never hardens, never invents a refusal.
- Applied at the CLI render boundary (`parse_cc → under_posture → render`), so
  `decide()` and the 67 hook tests are untouched.

## Tests

`tests/test_hook_ask_posture.py` (45 tests): the monotone-softening invariant,
the parse_cc round-trip for `ask`, the per-host render matrix (native CC-family,
non-blocking degrade elsewhere), the posture env/config precedence, and the
end-to-end "a real SELF_MODIFY deny becomes an ask under `gate`". Full non-slow
suite green (6037 passed; the 4 `test_hook_binary_locator` failures are an ambient
`DOS_HOOK_NATIVE=0` env leak, green when cleared — unrelated to this change).

## Roadmap to ~98% control-oriented coverage (docs/370 §6)

Phase A native per-host ASK · Phase B `HookAction.ALLOW` + the `assist`
verified-allowlist posture · Phase C posture-aware observation (`dos doctor`
shows escalated-vs-blocked) · Phase D the decision-inbox round-trip · Phase E
`dos init --posture gate` · Phase F Go fast-path parity.
