### PR TITLE
feat(hook): posture-aware observation + dos init --posture (docs/370 C, E)

### DIFF
--- a/docs/370_permission-controlled-posture-ask-and-the-human-in-the-loop.md
+++ b/docs/370_permission-controlled-posture-ask-and-the-human-in-the-loop.md
@@ -1,10 +1,16 @@
 # 370 — The permission-controlled posture: ASK and the human in the loop
 
-> **Status:** Phase 1 SHIPPED (the `ASK` action + the `Posture` seam +
-> Claude-Code-family native rendering). The roadmap phases (§6) are numbered,
-> each a litmus-checkable unit. Implementation: `hook_dialect.HookAction.ASK`,
-> `hook_dialect.Posture` / `parse_posture` / `under_posture`,
-> `cli._hook_posture`, `tests/test_hook_ask_posture.py`.
+> **Status:** Phase 1 + Phase C + Phase E SHIPPED. Phase 1 — the `ASK` action +
+> the `Posture` seam + Claude-Code-family native rendering. Phase C — posture-aware
+> observation: the PRE hook records the SURFACE the posture produced and `dos doctor`
+> splits the kernel's refusals into escalated-to-human vs hard-blocked vs observed.
+> Phase E — `dos init --posture <observe|block|gate>` wires the posture at install.
+> The remaining roadmap phases (§6) are numbered, each a litmus-checkable unit.
+> Implementation: `hook_dialect.HookAction.ASK`, `hook_dialect.Posture` /
+> `parse_posture` / `under_posture`, `cli._hook_posture` / `_effective_posture`,
+> `hook_observation.posture_split` (+ the `posture`/`surface` record fields),
+> `cli._upsert_enforcement_posture`; `tests/test_hook_ask_posture.py`,
+> `tests/test_posture_observation.py`, `tests/test_init_posture.py`.
 
 ## The wound, stated once
 
@@ -175,17 +181,32 @@ change.
   uncertain ones — a verified allowlist, not a static one. ALLOW must be strictly
   opt-in and refuse-narrow (auto-allow only what is provably safe; everything
   else still asks).
-- **Phase C — posture-aware observation.** `hook_observation` /
-  `dos doctor` should report *escalated-to-human* vs *hard-blocked* counts, so
-  the operator sees how often DOS hands them a call. Today the journal records
-  the kernel verdict (deny); the surface action (ask) is rendering-only.
+- **Phase C — posture-aware observation. ✅ SHIPPED.** The PRE hook now records,
+  off the `block` default, the POSTURE in effect and the SURFACE action it
+  produced (a deny is `surface=ask` under `gate`, `surface=warn` under `observe`)
+  as additive `hook_observation` fields — the `outcome` still records the kernel
+  verdict, so the refused/intervened denominator stays honest. `posture_split`
+  folds the refused records into `escalated` / `blocked` / `observed` (a total
+  partition; a posture-blind record counts as blocked), and `dos doctor` (text +
+  `--json`) shows the effective posture, its source, and the split — so a `gate`
+  operator sees how often DOS handed them a call. The default-`block` record is
+  byte-identical to the pre-posture one (the parity floor). `posture`/`surface`
+  carried into the Go decider's record is Phase F. Tests:
+  `tests/test_posture_observation.py`.
 - **Phase D — the decision-inbox round-trip.** An ASK the human DEFERS becomes a
   `decisions` row (the HUMAN resolver kind already exists, `decisions.py`), so a
   deferred escalation is not lost — it lands in the `dos decisions` queue.
-- **Phase E — `dos init --posture gate`.** Wire the control-oriented default at
-  install time and document the interplay with the host's OWN permission
-  settings (DOS `gate` + the host's allowlist are complementary: the allowlist
-  handles the routine, DOS escalates the adjudicated exceptions).
+- **Phase E — `dos init --posture gate`. ✅ SHIPPED.** `dos init --posture
+  <observe|block|gate>` writes `[enforcement] posture` into `dos.toml`. The choices
+  come from the `Posture` enum (the flag never drifts from the seam); the value is
+  MERGED into an existing config — a surgical, comment-preserving text upsert
+  (`_upsert_enforcement_posture`: append a documented table when absent, replace a
+  value in place when present, idempotent on a no-op) — so an operator turns `gate`
+  on in a repo that already has a `dos.toml` without `--force` clobbering the rest.
+  The `gate` confirmation documents the interplay with the host's OWN permission
+  settings (the allowlist handles the routine; DOS escalates the adjudicated
+  exceptions). A bare `dos init` is byte-for-byte the pre-Phase-E scaffold (no
+  `[enforcement]` table unless asked). Tests: `tests/test_init_posture.py`.
 - **Phase F — Go fast-path parity.** The native `dos-hook` binary serves the
   default BLOCK path; the posture transform is Python-side today. Carry the
   posture into the Go decider so a gated fleet keeps the fast path. (Default

--- a/src/dos/cli.py
+++ b/src/dos/cli.py
@@ -520,6 +520,85 @@ def _render_init_config(target: Path) -> tuple[str, str]:
     return "\n".join(lines), summary
 
 
+def _render_enforcement_block(posture: str) -> str:
+    """The documented `[enforcement]` TOML block for `dos init --posture` (docs/370 E).
+
+    A commented, self-explaining block — the posture is the one enforcement choice
+    an operator makes, so the scaffold spells out all three surfaces and the
+    per-run env override. PURE. Ends with a trailing newline (append-ready).
+    """
+    return (
+        "\n# How a DOS refusal is SURFACED to you (docs/370). DOS computes ONE\n"
+        "# verdict; the posture is YOUR choice of how it reaches you:\n"
+        '#   "block"   — a refusal hard-DENYs the call. DOS is the gate. The\n'
+        "#               headless / bypass-permissions default (the pre-posture bytes).\n"
+        '#   "gate"    — a refusal ESCALATES to your host\'s permission prompt (an\n'
+        '#               "ask") so YOU decide — the human-in-the-loop posture.\n'
+        "#               Complementary to your host's OWN allowlist: the allowlist\n"
+        "#               handles the routine, DOS escalates the adjudicated exceptions.\n"
+        '#   "observe" — a refusal degrades to an advisory note; records, never blocks.\n'
+        "# Override per run with the DOS_HOOK_POSTURE env (read on every hook event).\n"
+        "[enforcement]\n"
+        f'posture = "{posture}"\n'
+    )
+
+
+def _upsert_enforcement_posture(text: str, posture: str) -> "tuple[str, bool]":
+    """Set `[enforcement] posture` in a `dos.toml`'s TEXT, leaving the rest intact. PURE.
+
+    Returns `(new_text, changed)`. Three cases, all line-based (no TOML re-emit, so
+    every other table + its comments survive byte-for-byte):
+
+      * no `[enforcement]` table     → append a documented one.
+      * table present, no `posture`  → insert the `posture` line under its header.
+      * table present with `posture` → replace the value in place.
+
+    A value already equal to `posture` returns `(text, False)` — idempotent, so
+    re-running `dos init --posture X` is a no-op. The result always ends in a
+    single trailing newline.
+    """
+    lines = text.splitlines()
+    posture_line = f'posture = "{posture}"'
+
+    def _is_table_header(ln: str) -> bool:
+        s = ln.strip()
+        return s.startswith("[") and s.endswith("]")
+
+    def _is_posture_key(ln: str) -> bool:
+        return "=" in ln and ln.split("=", 1)[0].strip() == "posture"
+
+    hdr = next((i for i, ln in enumerate(lines)
+                if ln.strip() == "[enforcement]"), None)
+    if hdr is None:
+        return text.rstrip("\n") + "\n" + _render_enforcement_block(posture), True
+    # Scan the table body (until the next table header) for an existing posture key.
+    j = hdr + 1
+    while j < len(lines) and not _is_table_header(lines[j]):
+        if _is_posture_key(lines[j]):
+            if lines[j].strip() == posture_line:
+                return text, False
+            lines[j] = posture_line
+            return "\n".join(lines) + "\n", True
+        j += 1
+    lines.insert(hdr + 1, posture_line)
+    return "\n".join(lines) + "\n", True
+
+
+def _apply_enforcement_posture(cfg_path: Path, posture: str) -> bool:
+    """Write `[enforcement] posture = <posture>` into `cfg_path`. Returns `changed`.
+
+    The I/O wrapper over the pure `_upsert_enforcement_posture`: read the existing
+    `dos.toml`, upsert the posture, write back only if it changed. The boundary the
+    `dos init --posture` path calls so an operator can turn the posture on in a
+    workspace that already has a `dos.toml`, without `--force` clobbering the rest.
+    """
+    text = cfg_path.read_text(encoding="utf-8") if cfg_path.exists() else ""
+    new_text, changed = _upsert_enforcement_posture(text, posture)
+    if changed:
+        cfg_path.write_text(new_text, encoding="utf-8")
+    return changed
+
+
 def _resolve_driver_taxonomy(name: str):
     """The `LaneTaxonomy` of a named driver pack — the single source of truth.
 
@@ -1062,6 +1141,14 @@ def cmd_init(args: argparse.Namespace) -> int:
         hook_host = "claude-code"
     want_hooks = hook_host is not None
 
+    # docs/370 Phase E — `dos init --posture <observe|block|gate>`: wire the
+    # enforcement POSTURE (how a DOS refusal is surfaced) at install time. Like
+    # --skills / --hooks it is a valid reason to touch an EXISTING workspace
+    # (merge the posture into its dos.toml without --force clobbering the rest),
+    # so an operator can turn `gate` on in a repo that already has a config.
+    posture = getattr(args, "posture", None)
+    want_posture = posture is not None
+
     # `--dry-run` is a PREVIEW of the hook merge — it touches nothing. It is only
     # meaningful with --hooks (there is nothing else to preview), and it skips the
     # dos.toml scaffold + skills copy so "dry-run wrote nothing" is literally true.
@@ -1076,9 +1163,10 @@ def cmd_init(args: argparse.Namespace) -> int:
     if dry_run:
         pass  # preview-only: do not scaffold dos.toml or copy skills
     elif config_existed and not args.force:
-        # When ONLY copying skills / wiring hooks into an existing workspace, the
-        # pre-existing dos.toml is not an error — skip the scaffold and proceed.
-        if not (want_skills or want_hooks):
+        # When ONLY copying skills / wiring hooks / setting the posture into an
+        # existing workspace, the pre-existing dos.toml is not an error — skip the
+        # scaffold and proceed (the posture is merged in below, not clobbered).
+        if not (want_skills or want_hooks or want_posture):
             print(f"{cfg_path} already exists (use --force to overwrite)", file=sys.stderr)
             return 1
     else:
@@ -1106,6 +1194,23 @@ def cmd_init(args: argparse.Namespace) -> int:
             cfg_path.write_text(config_text, encoding="utf-8")
             print(f"wrote {cfg_path}")
             print(summary)
+
+    # docs/370 Phase E — merge the chosen posture into the dos.toml just written
+    # (or the pre-existing one we left untouched above). After the scaffold so a
+    # freshly-rendered config gets its `[enforcement]` block, and after the
+    # --example path so a driver-pack config gets it too — one home for the upsert.
+    if want_posture and not dry_run:
+        changed = _apply_enforcement_posture(cfg_path, posture)
+        if changed:
+            print(f"set enforcement posture = \"{posture}\" in {cfg_path}")
+            if posture == "gate":
+                print("  gate: a DOS refusal now ESCALATES to your host's permission "
+                      "prompt (an ask) instead of hard-blocking — you decide. It "
+                      "complements your host's OWN allowlist (allowlist handles the "
+                      "routine; DOS escalates the adjudicated exceptions). Override "
+                      "per run with DOS_HOOK_POSTURE.")
+        else:
+            print(f"enforcement posture already \"{posture}\" in {cfg_path} (no change)")
 
     if want_skills and not dry_run:
         if getattr(args, "all", False):
@@ -5645,25 +5750,43 @@ def cmd_hook_posttool(args: argparse.Namespace) -> int:
     return 0
 
 
+def _effective_posture(cfg) -> "tuple":
+    """The effective enforcement POSTURE + WHERE it came from (docs/370).
+
+    The single home of the posture-precedence read: the `DOS_HOOK_POSTURE` env (a
+    fleet-wide override, read per-call like `DOS_APPLY_GATE`), then
+    `dos.toml [enforcement] posture`, then the BLOCK default. Returns
+    `(hook_dialect.Posture, source)` where `source` ∈ {"env", "config", "default"}.
+    The hook hot path takes only the posture (`_hook_posture`); `dos doctor` takes
+    the source too, so its report says not just WHAT posture is live but WHY. Any
+    shape miss degrades to the default (which `parse_posture` also enforces), so a
+    torn config never breaks the read.
+    """
+    from dos import hook_dialect as _hd
+    env = os.environ.get("DOS_HOOK_POSTURE", "").strip()
+    if env:
+        return _hd.parse_posture(env), "env"
+    try:
+        table = _config._load_toml_table(Path(cfg.root) / "dos.toml", "enforcement")
+        if isinstance(table, dict):
+            name = str(table.get("posture") or "").strip()
+            if name:
+                return _hd.parse_posture(name), "config"
+    except Exception:  # noqa: BLE001 — a torn/absent config never breaks the hook
+        pass
+    return _hd.DEFAULT_POSTURE, "default"
+
+
 def _hook_posture(cfg) -> "object":
     """The operator's declared enforcement POSTURE for this workspace (docs/370).
 
-    Boundary read — the one I/O behind the pure `hook_dialect.under_posture`. Precedence:
-    the `DOS_HOOK_POSTURE` env (a fleet-wide override, read per-call like
-    `DOS_APPLY_GATE`), then `dos.toml [enforcement] posture`, then the BLOCK default.
-    Any shape miss degrades to the default (which `parse_posture` also enforces), so a
-    malformed config never breaks the hook hot path. Returns a `hook_dialect.Posture`.
+    Boundary read — the one I/O behind the pure `hook_dialect.under_posture`. Thin
+    over `_effective_posture` (the shared precedence: env › `dos.toml` › BLOCK
+    default); the hook hot path does not need the source, only the posture.
+    Returns a `hook_dialect.Posture`.
     """
-    from dos import hook_dialect as _hd
-    name = os.environ.get("DOS_HOOK_POSTURE", "").strip()
-    if not name:
-        try:
-            table = _config._load_toml_table(Path(cfg.root) / "dos.toml", "enforcement")
-            if isinstance(table, dict):
-                name = str(table.get("posture") or "").strip()
-        except Exception:  # noqa: BLE001 — a torn/absent config never breaks the hook
-            name = ""
-    return _hd.parse_posture(name)
+    posture, _source = _effective_posture(cfg)
+    return posture
 
 
 def cmd_hook_pretool(args: argparse.Namespace) -> int:
@@ -5756,6 +5879,16 @@ def cmd_hook_pretool(args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001 — observability is best-effort, never blocking
             _dbg(f"help-nudge fold error ({exc!r}) — emitting outcome without nudge")
 
+    # docs/370 — the operator's enforcement POSTURE, read ONCE here so the same
+    # value drives the render (`under_posture`) and the observation record below.
+    posture = _hook_posture(cfg)
+    # How the posture SURFACED the verdict to the operator (docs/370 Phase C). The
+    # default `block` surface IS the kernel verdict (a deny stays a deny); under
+    # `gate` a deny becomes `ask`, under `observe` a `warn`. Defaults to the kernel
+    # decision so a passthrough / a render this hook never re-shapes still has a
+    # truthful surface.
+    surface = str(decision)
+
     # 6. The ONLY thing on stdout: the host's PRE dialect, or nothing. `decide()`
     #   (full prose: docs/CLI.md § "6. The ONLY thing on stdout: the host's PRE dialect, or noth")
     if dialect is not None:
@@ -5773,8 +5906,9 @@ def cmd_hook_pretool(args: argparse.Namespace) -> int:
             # the loop sets `gate` to ESCALATE a refusal to their permission prompt
             # (an ASK) instead of a hard block; `observe` records only. Default BLOCK
             # is byte-for-byte today's behavior (the parity floor). The transform is
-            # pure; the env/config read is the one boundary line here.
-            verdict = _hd.under_posture(verdict, _hook_posture(cfg))
+            # pure; the env/config read happened once above.
+            verdict = _hd.under_posture(verdict, posture)
+            surface = verdict.action.value  # what the operator SAW (docs/370 Phase C)
             host_dialect = renderer.render(verdict)
         except ValueError as exc:  # unknown dialect name — surface, do not guess a host
             _dbg(f"dialect error ({exc}) — emitting nothing (passthrough)")
@@ -5788,13 +5922,24 @@ def cmd_hook_pretool(args: argparse.Namespace) -> int:
     #    the call a binary DELEGATED here (the docs/297 pairing). Fail-soft,
     #    strictly downstream of the emitted dialect.
     from dos.hook_dialect import DEFAULT_DIALECT as _default_dialect
+    from dos.hook_dialect import DEFAULT_POSTURE as _default_posture
+    # docs/370 Phase C — carry the posture + surfaced action ONLY off the BLOCK
+    # default, so a default-posture record is byte-identical to a pre-posture one
+    # (the parity floor): under `block` the surface is the verdict, nothing new to
+    # record. Under `gate`/`observe` the two fields let `dos doctor` split the
+    # kernel's refusals into escalated-to-human vs hard-blocked vs observed.
+    _posture_fields = (
+        {} if posture is _default_posture
+        else {"posture": posture.value, "surface": surface}
+    )
     _record_hook_observation(cfg, verb="pretool", outcome=str(decision),
                              started=started, debug=debug,
                              rung=str(outcome.get("rung") or ""),
                              reason_class=str(outcome.get("reason_class") or ""),
                              dialect=str(getattr(args, "dialect", None) or _default_dialect),
                              tree_known=(bool(outcome["tree_known"])
-                                         if "tree_known" in outcome else None))
+                                         if "tree_known" in outcome else None),
+                             **_posture_fields)
     return 0
 
 
@@ -8162,6 +8307,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         if _skill_findings and bool(getattr(args, "skill_strict", False)):
             gating = True
 
+    # docs/370 Phase C — the effective enforcement POSTURE + the escalated-vs-blocked
+    # split over the observation log, computed ONCE for both the JSON and text
+    # reports. A `gate` operator keeps a human in the loop, so the report must show
+    # not just WHICH posture is live (and from where) but how often DOS actually
+    # handed the human a call vs hard-blocked it. Fail-soft: a torn log degrades the
+    # split to its empty value — a report row never breaks doctor.
+    _posture, _posture_source = _effective_posture(cfg)
+    try:
+        from dos import hook_observation as _hobs_doctor
+        _posture_split = _hobs_doctor.posture_split(_hobs_doctor.read_observations(cfg=cfg))
+    except Exception:  # noqa: BLE001 — a telemetry read fault never breaks the report
+        from dos.hook_observation import PostureSplit as _PostureSplit
+        _posture_split = _PostureSplit()
+
     # SKP Phase 1a — `dos doctor --json`: the machine-readable workspace report a
     #   (full prose: docs/CLI.md § "SKP Phase 1a — `dos doctor --json`: the machine-readable wor")
     if getattr(args, "json", False):
@@ -8243,6 +8402,16 @@ def cmd_doctor(args: argparse.Namespace) -> int:
                 "ratio_max": cfg.overlap_ratio_max,
                 "floor": "prefix",
             },
+            # docs/370 — the enforcement POSTURE (how a DOS refusal is SURFACED) +
+            # the escalated-vs-blocked split over the observation log. `posture` is
+            # the effective choice, `source` says where it came from (env › config ›
+            # default), `surfaced_refusals` is the per-call tally a `gate` operator
+            # reads to see how often DOS handed them the call instead of blocking it.
+            "enforcement": {
+                "posture": _posture.value,
+                "source": _posture_source,
+                "surfaced_refusals": _posture_split.to_dict(),
+            },
             # The verdict-IS-the-exit-code contract, per verb (item 1). An agent
             # reads this once to learn that `verify` exits 0/1, `liveness`
             # SPINNING is 3, `gate` DRAIN is 3, etc. — instead of reverse-
@@ -8298,6 +8467,25 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # docs/189 §A1 — the enforcement handlers that CONSUME an intervention decision
     #   (full prose: docs/CLI.md § "docs/189 §A1 — the enforcement handlers that CONSUME an inte")
     print(f"enforce handlers     {', '.join(_enforce_handler_names())}")
+    # docs/370 — the enforcement POSTURE: how a DOS refusal is SURFACED to the
+    # operator. `block` (the default) hard-denies (DOS is the gate — the headless
+    # deployment); `gate` escalates a refusal to the host's permission prompt (an
+    # "ask" — the human-in-the-loop deployment); `observe` records only. The line
+    # names where the live value came from (env › dos.toml › default) so a stray
+    # `DOS_HOOK_POSTURE` is visible, and — when the observation log has witnessed
+    # refusals — splits them into escalated-to-human vs hard-blocked vs observed,
+    # so a `gate` operator sees how often DOS handed them a call (docs/370 Phase C).
+    _posture_desc = {
+        "block": "a refusal hard-DENYs — DOS is the gate (the headless default)",
+        "gate": "a refusal ESCALATEs to your permission prompt (an ask) — human in the loop",
+        "observe": "a refusal degrades to an advisory note — records only",
+    }.get(_posture.value, _posture.value)
+    print(f"enforcement posture {_posture.value}  ({_posture_desc}; from {_posture_source})")
+    if _posture_split.refused:
+        print(f"  surfaced refusals {_posture_split.refused}: "
+              f"{_posture_split.escalated} escalated-to-human, "
+              f"{_posture_split.blocked} hard-blocked, "
+              f"{_posture_split.observed} observed-only")
     # Axis 7 — the disjointness SCORER the arbiter admits on (docs/113). Shows the
     #   (full prose: docs/CLI.md § "Axis 7 — the disjointness SCORER the arbiter admits on (docs")
     _ov_active = cfg.overlap_policy_name or "prefix"
@@ -10557,6 +10745,18 @@ def build_parser() -> argparse.ArgumentParser:
     pi.add_argument("--with-hooks", action="store_true", dest="with_hooks",
                     help="alias for --hooks claude-code (wire the DOS hooks into "
                          ".claude/settings.json)")
+    # docs/370 Phase E — wire the enforcement POSTURE at install time. Choices come
+    # from the kernel's `Posture` enum so the flag never drifts from the seam.
+    from dos import hook_dialect as _hd_choices
+    pi.add_argument("--posture", metavar="MODE",
+                    choices=[p.value for p in _hd_choices.Posture],
+                    help="set how a DOS refusal is SURFACED, written to "
+                         "dos.toml [enforcement] posture (merged into an existing "
+                         "config, no --force needed): 'block' hard-denies (DOS is "
+                         "the gate — the headless default), 'gate' escalates a "
+                         "refusal to your host's permission prompt (an ask — the "
+                         "human-in-the-loop posture), 'observe' records only. "
+                         "Override per run with the DOS_HOOK_POSTURE env.")
     pi.add_argument("--dry-run", action="store_true", dest="dry_run",
                     help="with --hooks: PREVIEW the config merge (print what would "
                          "be written, write nothing) — the dress rehearsal before "

--- a/src/dos/hook_observation.py
+++ b/src/dos/hook_observation.py
@@ -123,6 +123,8 @@ def observation_entry(
     rung: str = "",
     reason_class: str = "",
     dialect: str = "",
+    posture: str = "",
+    surface: str = "",
     tree_known: Optional[bool] = None,
     stream_state: str = "",
     marker_count: int = 0,
@@ -167,6 +169,17 @@ def observation_entry(
         e["reason_class"] = reason_class
     if dialect:
         e["dialect"] = dialect
+    # docs/370 Phase C — the enforcement POSTURE in effect and the SURFACE action it
+    # produced (how a kernel refusal reached the operator). Written ONLY off the
+    # BLOCK default, so a default-posture record stays byte-identical to a
+    # pre-posture one (the additive contract + the docs/370 parity floor): under
+    # `block` the surface IS the verdict, so there is nothing new to say. Under
+    # `gate` a deny surfaced as `ask` (escalated to the human); under `observe` as
+    # `warn` (recorded only) — the split `posture_split` reads.
+    if posture:
+        e["posture"] = posture
+    if surface:
+        e["surface"] = surface
     if tree_known is not None:
         e["tree_known"] = bool(tree_known)
     if stream_state:
@@ -462,6 +475,91 @@ def intervention_rate(records: Iterable[dict], *, since: str = "") -> Interventi
         advised=advised,
         delegated=delegated,
     )
+
+
+# ---------------------------------------------------------------------------
+# The posture split (docs/370 Phase C) — of the kernel's pretool REFUSALS, how
+# many were hard-BLOCKED vs ESCALATED to a human vs softened to an OBSERVE note.
+# The kernel computes ONE verdict (a deny); the posture chooses how it is
+# surfaced. The `outcome` field still records the kernel verdict (so the
+# refused/intervened denominator is untouched — docs/370 keeps the journal honest
+# about what the kernel DECIDED); the `surface` field records what the operator
+# actually SAW. This fold reads the surface, so an operator who runs `gate` can
+# see how often DOS handed them a call instead of deciding for them.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PostureSplit:
+    """How the kernel's pretool REFUSALS were surfaced under the operator's posture.
+
+    Over the same refused pretool records `intervention_rate` counts (an `outcome`
+    in {deny, block}), split by the `surface` action the posture produced:
+
+      * ``blocked``   — surfaced as a hard DENY (the `block` posture, the default).
+      * ``escalated`` — surfaced as an ASK at the human's permission prompt (`gate`).
+      * ``observed``  — softened to an advisory WARN, recorded only (`observe`).
+
+    A refused record with no `surface` field — one written before docs/370 Phase C,
+    or by a posture-blind writer like the Go binary — counts as ``blocked``: the
+    BLOCK-default assumption, behavior-preserving. The partition is total, so
+    ``refused == blocked + escalated + observed`` on every fold (an invariant a
+    test pins). All counts come from ONE observation log; the lane journal has no
+    path in (the like-for-like rule `intervention_rate` already holds).
+    """
+
+    refused: int = 0
+    blocked: int = 0
+    escalated: int = 0
+    observed: int = 0
+
+    @property
+    def escalated_pct(self) -> float:
+        if self.refused <= 0:
+            return 0.0
+        return self.escalated * 100.0 / self.refused
+
+    def to_dict(self) -> dict:
+        return {
+            "refused": self.refused,
+            "blocked": self.blocked,
+            "escalated": self.escalated,
+            "observed": self.observed,
+            "escalated_pct": round(self.escalated_pct, 1),
+        }
+
+
+def posture_split(records: Iterable[dict], *, since: str = "") -> PostureSplit:
+    """Fold observation records into the posture split (escalated-vs-blocked). PURE.
+
+    Counts every refused pretool record (an `outcome` in {deny, block}) and buckets
+    it by its `surface` field: ``ask`` → escalated, ``warn`` → observed, anything
+    else (``deny``, or an absent field) → blocked. `since` keeps records with
+    `ts >= since` (ISO-8601 lexical compare; an undatable record is skipped under a
+    window — the conservative direction `intervention_rate` already takes).
+
+    Records in, value out, no disk — the unit-test surface. Like `intervention_rate`
+    the signature takes observation records ONLY, so no other log can enter the count.
+    """
+    refused = blocked = escalated = observed = 0
+    for rec in records:
+        if rec.get("verb") != "pretool":
+            continue
+        ts = str(rec.get("ts") or "")
+        if since and (not ts or ts < since):
+            continue
+        if str(rec.get("outcome") or "") not in _REFUSED_OUTCOMES:
+            continue
+        refused += 1
+        surface = str(rec.get("surface") or "")
+        if surface == "ask":
+            escalated += 1
+        elif surface == "warn":
+            observed += 1
+        else:  # "deny", or unset (a pre-Phase-C / posture-blind record) → hard-blocked
+            blocked += 1
+    return PostureSplit(refused=refused, blocked=blocked,
+                        escalated=escalated, observed=observed)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init_posture.py
+++ b/tests/test_init_posture.py
@@ -1,0 +1,169 @@
+"""docs/370 Phase E — `dos init --posture`: wire the enforcement posture at install.
+
+Phase A added the posture seam (env / `dos.toml [enforcement] posture`); without an
+install affordance an operator had to hand-edit TOML to turn the control-oriented
+`gate` posture on. This suite pins the `dos init --posture <mode>` on-ramp:
+
+  * the pure text upsert (`_upsert_enforcement_posture`) — append when no table,
+    insert under an existing header, replace an existing value, idempotent on a
+    no-op — never re-emitting (and so never reordering / decommenting) the file;
+  * the CLI writes `[enforcement] posture` on a fresh scaffold AND merges it into a
+    pre-existing `dos.toml` without `--force` clobbering the lanes;
+  * an invalid posture is rejected by the parser (the choices come from the seam);
+  * the round-trip: `dos init --posture gate` then `dos doctor --json` reads it
+    back as the effective posture from config (Phase C).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import dos
+from dos import cli
+
+
+def _cli(*argv: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": str(Path(dos.__file__).parents[1])}
+    # Strip a leaked posture env so doctor reads the CONFIG, not a fleet override.
+    env.pop("DOS_HOOK_POSTURE", None)
+    return subprocess.run(
+        [sys.executable, "-m", "dos.cli", *argv],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The pure text upsert — surgical, comment-preserving, idempotent.
+# ---------------------------------------------------------------------------
+def test_upsert_appends_when_no_enforcement_table():
+    text = '[lanes]\nconcurrent = ["src"]\n'
+    out, changed = cli._upsert_enforcement_posture(text, "gate")
+    assert changed
+    assert text in out                       # the original survives byte-for-byte
+    assert "[enforcement]" in out
+    assert 'posture = "gate"' in out
+    assert out.endswith("\n")
+
+
+def test_upsert_inserts_under_existing_header_without_posture():
+    text = "[enforcement]\n# some note\n"
+    out, changed = cli._upsert_enforcement_posture(text, "gate")
+    assert changed
+    assert '[enforcement]\nposture = "gate"' in out
+    assert "# some note" in out
+
+
+def test_upsert_replaces_an_existing_value_in_place():
+    text = '[enforcement]\nposture = "block"\n[other]\nx = 1\n'
+    out, changed = cli._upsert_enforcement_posture(text, "gate")
+    assert changed
+    assert 'posture = "gate"' in out
+    assert 'posture = "block"' not in out
+    assert "[other]\nx = 1" in out           # the trailing table is untouched
+    assert out.count("[enforcement]") == 1   # no duplicate table
+
+
+def test_upsert_is_idempotent_on_a_noop():
+    text = '[enforcement]\nposture = "gate"\n'
+    out, changed = cli._upsert_enforcement_posture(text, "gate")
+    assert not changed
+    assert out == text
+
+
+def test_upsert_only_matches_the_posture_key_not_a_lookalike():
+    """A `posture_note` key is NOT the posture value — the upsert sets posture
+    separately, it does not rewrite a different key that starts with `posture`."""
+    text = '[enforcement]\nposture_note = "x"\n'
+    out, _ = cli._upsert_enforcement_posture(text, "gate")
+    assert 'posture_note = "x"' in out
+    assert 'posture = "gate"' in out
+
+
+# ---------------------------------------------------------------------------
+# The CLI — fresh scaffold, existing-config merge, idempotency, validation.
+# ---------------------------------------------------------------------------
+def _enforcement_posture(cfg_path: Path) -> str:
+    import tomllib
+    data = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
+    return data["enforcement"]["posture"]
+
+
+def test_init_posture_writes_enforcement_table(tmp_path: Path):
+    dest = tmp_path / "svc"
+    proc = _cli("init", "--posture", "gate", str(dest))
+    assert proc.returncode == 0, proc.stderr
+    cfg = dest / "dos.toml"
+    assert cfg.is_file()
+    assert _enforcement_posture(cfg) == "gate"
+    assert "gate" in proc.stdout  # the operator is told what changed
+
+
+def test_init_posture_merges_into_existing_config_without_force(tmp_path: Path):
+    dest = tmp_path / "svc"
+    # First a normal scaffold (lanes derived), then turn the posture on — no --force.
+    assert _cli("init", str(dest)).returncode == 0
+    before = (dest / "dos.toml").read_text(encoding="utf-8")
+    assert "[enforcement]" not in before  # the default scaffold has no posture table
+    proc = _cli("init", "--posture", "gate", str(dest))
+    assert proc.returncode == 0, proc.stderr
+    after = (dest / "dos.toml").read_text(encoding="utf-8")
+    assert _enforcement_posture(dest / "dos.toml") == "gate"
+    assert "[lanes]" in after                 # the lanes the first scaffold wrote survive
+    assert before.rstrip("\n") in after       # nothing the first pass wrote was lost
+
+
+def test_init_posture_change_in_place(tmp_path: Path):
+    dest = tmp_path / "svc"
+    assert _cli("init", "--posture", "gate", str(dest)).returncode == 0
+    proc = _cli("init", "--posture", "observe", str(dest))
+    assert proc.returncode == 0, proc.stderr
+    assert _enforcement_posture(dest / "dos.toml") == "observe"
+    # No duplicate table left behind by the re-run.
+    assert (dest / "dos.toml").read_text(encoding="utf-8").count("[enforcement]") == 1
+
+
+def test_init_posture_idempotent_reports_no_change(tmp_path: Path):
+    dest = tmp_path / "svc"
+    assert _cli("init", "--posture", "gate", str(dest)).returncode == 0
+    proc = _cli("init", "--posture", "gate", str(dest))
+    assert proc.returncode == 0, proc.stderr
+    assert "no change" in proc.stdout
+    assert _enforcement_posture(dest / "dos.toml") == "gate"
+
+
+def test_init_invalid_posture_is_rejected(tmp_path: Path):
+    proc = _cli("init", "--posture", "yolo", str(tmp_path / "svc"))
+    assert proc.returncode != 0
+    assert "invalid choice" in proc.stderr or "yolo" in proc.stderr
+
+
+def test_init_posture_on_example_pack(tmp_path: Path):
+    """The posture rides the --example driver-pack path too (one upsert home)."""
+    dest = tmp_path / "svc"
+    proc = _cli("init", "--example", "workshop", "--posture", "gate", str(dest))
+    assert proc.returncode == 0, proc.stderr
+    assert _enforcement_posture(dest / "dos.toml") == "gate"
+
+
+# ---------------------------------------------------------------------------
+# The round-trip — init writes it, doctor reads it back (Phase E meets Phase C).
+# ---------------------------------------------------------------------------
+def test_init_then_doctor_reads_the_posture_from_config(tmp_path: Path):
+    dest = tmp_path / "svc"
+    assert _cli("init", "--posture", "gate", str(dest)).returncode == 0
+    proc = _cli("doctor", "--workspace", str(dest), "--json")
+    assert proc.returncode == 0, proc.stderr
+    enf = json.loads(proc.stdout)["enforcement"]
+    assert enf["posture"] == "gate"
+    assert enf["source"] == "config"
+
+
+def test_init_default_scaffold_unchanged_without_posture(tmp_path: Path):
+    """No --posture → the scaffold is byte-for-byte the pre-Phase-E one (no
+    `[enforcement]` table appears unless the operator asks for it)."""
+    dest = tmp_path / "svc"
+    assert _cli("init", str(dest)).returncode == 0
+    assert "[enforcement]" not in (dest / "dos.toml").read_text(encoding="utf-8")

--- a/tests/test_posture_observation.py
+++ b/tests/test_posture_observation.py
@@ -1,0 +1,247 @@
+"""docs/370 Phase C — posture-aware observation: escalated-to-human vs hard-blocked.
+
+The kernel computes ONE pretool verdict (a deny); the operator's POSTURE chooses
+how it is surfaced — a hard block, an `ask` at the human's prompt, or an advisory
+note. Phase A recorded only the kernel verdict (`outcome=deny`), so the surface
+action was rendering-only and invisible to the operator. This suite pins the
+Phase-C observation seam:
+
+  * `observation_entry` carries the `posture` + `surface` fields ONLY when set, so
+    a default-`block` record stays byte-identical to a pre-posture one (the
+    additive contract + the docs/370 parity floor).
+  * `posture_split` folds the refused pretool records into escalated / blocked /
+    observed, with `refused == blocked + escalated + observed` (a total partition)
+    and a back-compat rule: a refused record with no `surface` counts as blocked.
+  * The end-to-end PRE hook records the surface the posture produced (a deny is
+    `surface=ask` under gate, `surface=warn` under observe, and writes NEITHER
+    field under the block default).
+  * `dos doctor` (text + `--json`) surfaces the effective posture, where it came
+    from, and the escalated-vs-blocked split.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from dos import config as _config
+from dos import hook_observation as hobs
+
+
+# ---------------------------------------------------------------------------
+# observation_entry — the posture/surface fields are additive (parity floor).
+# ---------------------------------------------------------------------------
+def test_entry_omits_posture_and_surface_when_unset():
+    """A default record names neither field — byte-identical to a pre-Phase-C one."""
+    e = hobs.observation_entry("pretool", "deny")
+    assert "posture" not in e
+    assert "surface" not in e
+
+
+def test_entry_carries_posture_and_surface_when_set():
+    e = hobs.observation_entry("pretool", "deny", posture="gate", surface="ask")
+    assert e["posture"] == "gate"
+    assert e["surface"] == "ask"
+
+
+# ---------------------------------------------------------------------------
+# posture_split — the pure fold (escalated / blocked / observed).
+# ---------------------------------------------------------------------------
+def _rec(outcome="deny", surface=None, verb="pretool", ts="2026-06-16T00:00:00Z"):
+    r = {"verb": verb, "outcome": outcome, "ts": ts}
+    if surface is not None:
+        r["surface"] = surface
+    return r
+
+
+def test_split_buckets_by_surface():
+    recs = [
+        _rec(surface="ask"), _rec(surface="ask"),     # escalated
+        _rec(surface="deny"),                          # blocked
+        _rec(surface="warn"),                          # observed
+        _rec(surface=None),                            # blocked (no surface → back-compat)
+        _rec(outcome="passthrough"),                   # not refused → ignored
+        _rec(outcome="block", surface="ask", verb="stop"),  # not pretool → ignored
+    ]
+    s = hobs.posture_split(recs)
+    assert (s.refused, s.escalated, s.blocked, s.observed) == (5, 2, 2, 1)
+    assert s.escalated_pct == 40.0
+
+
+def test_split_partition_invariant_is_total():
+    """Every refused record lands in exactly one bucket — no double-count, no drop."""
+    recs = [_rec(surface=x) for x in ("ask", "deny", "warn", None, "ask", "deny")]
+    s = hobs.posture_split(recs)
+    assert s.refused == s.blocked + s.escalated + s.observed
+
+
+def test_split_missing_surface_counts_as_blocked():
+    """A posture-blind writer (the Go binary) / a pre-Phase-C record has no surface
+    field; it counts as a hard block — the BLOCK-default, behavior-preserving read."""
+    s = hobs.posture_split([_rec(surface=None), _rec(outcome="block")])
+    assert (s.refused, s.blocked, s.escalated, s.observed) == (2, 2, 0, 0)
+
+
+def test_split_honors_the_since_window():
+    recs = [
+        _rec(surface="ask", ts="2026-06-15T00:00:00Z"),   # before window
+        _rec(surface="ask", ts="2026-06-16T12:00:00Z"),   # in window
+    ]
+    s = hobs.posture_split(recs, since="2026-06-16T00:00:00Z")
+    assert (s.refused, s.escalated) == (1, 1)
+
+
+def test_split_empty_is_all_zero():
+    s = hobs.posture_split([])
+    assert s.to_dict() == {"refused": 0, "blocked": 0, "escalated": 0,
+                           "observed": 0, "escalated_pct": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the PRE hook records the SURFACE the posture produced.
+# ---------------------------------------------------------------------------
+def _patch_deny(monkeypatch):
+    """Make decide() return a real-shaped SELF_MODIFY deny, so the hook re-shapes it
+    under the posture and records the resulting surface (no kernel-repo needed)."""
+    cc = {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "blocked by DOS (SELF_MODIFY)"}}
+    outcome = {"decision": "deny", "rung": "B",
+               "reason_class": "SELF_MODIFY", "tree_known": True}
+    monkeypatch.setattr("dos.pretool_sensor.decide",
+                        lambda event, cfg, handler_name="observe": (cc, outcome))
+
+
+def _run_pretool(monkeypatch, tmp_path, *, posture=None):
+    from dos import cli
+    monkeypatch.setenv("DISPATCH_WORKSPACE", str(tmp_path))
+    if posture is None:
+        monkeypatch.delenv("DOS_HOOK_POSTURE", raising=False)
+    else:
+        monkeypatch.setenv("DOS_HOOK_POSTURE", posture)
+    event = {"tool_name": "Write", "session_id": "S1",
+             "tool_input": {"file_path": "src/dos/arbiter.py", "content": "x"},
+             "cwd": str(tmp_path)}
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
+    buf = io.StringIO()
+    monkeypatch.setattr("sys.stdout", buf)
+    args = cli.argparse.Namespace(
+        workspace=None, driver=None, job=False, handler="observe", debug=False)
+    rc = cli.cmd_hook_pretool(args)
+    return buf.getvalue(), rc
+
+
+def _last_pretool_record(tmp_path):
+    recs = hobs.read_observations(cfg=_config.default_config(tmp_path))
+    pre = [r for r in recs if r.get("verb") == "pretool"]
+    assert pre, "no pretool observation recorded"
+    return pre[-1]
+
+
+def test_block_default_records_no_posture_or_surface(monkeypatch, tmp_path):
+    """The parity floor at the OBSERVATION layer: a deny under the block default
+    surfaces as a deny and records NEITHER new field — byte-identical to today."""
+    _patch_deny(monkeypatch)
+    out, rc = _run_pretool(monkeypatch, tmp_path, posture=None)
+    assert rc == 0
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+    rec = _last_pretool_record(tmp_path)
+    assert rec["outcome"] == "deny"
+    assert "posture" not in rec and "surface" not in rec
+
+
+def test_gate_records_surface_ask(monkeypatch, tmp_path):
+    _patch_deny(monkeypatch)
+    out, rc = _run_pretool(monkeypatch, tmp_path, posture="gate")
+    assert rc == 0
+    # The operator SAW an ask (escalated), but the kernel verdict on the journal
+    # is still the deny — the denominator the refused-rate reads stays honest.
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "ask"
+    rec = _last_pretool_record(tmp_path)
+    assert rec["outcome"] == "deny"
+    assert rec["posture"] == "gate"
+    assert rec["surface"] == "ask"
+
+
+def test_observe_records_surface_warn(monkeypatch, tmp_path):
+    _patch_deny(monkeypatch)
+    out, rc = _run_pretool(monkeypatch, tmp_path, posture="observe")
+    assert rc == 0
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert "permissionDecision" not in hso  # observe never blocks, never prompts
+    rec = _last_pretool_record(tmp_path)
+    assert rec["outcome"] == "deny"
+    assert rec["posture"] == "observe"
+    assert rec["surface"] == "warn"
+
+
+def test_split_reads_the_recorded_surfaces_end_to_end(monkeypatch, tmp_path):
+    """A gate deny then an observe deny → the fold over the SAME log reports one
+    escalated + one observed (the operator's escalated-vs-blocked view)."""
+    _patch_deny(monkeypatch)
+    _run_pretool(monkeypatch, tmp_path, posture="gate")
+    _run_pretool(monkeypatch, tmp_path, posture="observe")
+    s = hobs.posture_split(hobs.read_observations(cfg=_config.default_config(tmp_path)))
+    assert (s.refused, s.escalated, s.observed, s.blocked) == (2, 1, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# dos doctor — surfaces the effective posture + the split (text + JSON).
+# ---------------------------------------------------------------------------
+def _doctor_args(tmp_path, *, as_json=False):
+    from dos import cli
+    return cli.argparse.Namespace(
+        workspace=str(tmp_path), json=as_json, check=False, wiring=False,
+        skill_strict=False, driver=None)
+
+
+def _seed_observations(tmp_path, rows):
+    cfg = _config.default_config(tmp_path)
+    for r in rows:
+        hobs.append(hobs.observation_entry("pretool", r["outcome"],
+                                           posture=r.get("posture", ""),
+                                           surface=r.get("surface", "")),
+                    cfg=cfg, debug=True)
+
+
+def test_doctor_json_reports_posture_and_split(monkeypatch, tmp_path, capsys):
+    from dos import cli
+    (tmp_path / "dos.toml").write_text('[enforcement]\nposture = "gate"\n', encoding="utf-8")
+    monkeypatch.delenv("DOS_HOOK_POSTURE", raising=False)
+    _seed_observations(tmp_path, [
+        {"outcome": "deny", "posture": "gate", "surface": "ask"},
+        {"outcome": "deny", "posture": "gate", "surface": "ask"},
+        {"outcome": "deny"},  # a block-default record → hard-blocked
+    ])
+    cli.cmd_doctor(_doctor_args(tmp_path, as_json=True))
+    report = json.loads(capsys.readouterr().out)
+    enf = report["enforcement"]
+    assert enf["posture"] == "gate"
+    assert enf["source"] == "config"
+    assert enf["surfaced_refusals"]["refused"] == 3
+    assert enf["surfaced_refusals"]["escalated"] == 2
+    assert enf["surfaced_refusals"]["blocked"] == 1
+
+
+def test_doctor_text_names_the_posture_and_escalations(monkeypatch, tmp_path, capsys):
+    from dos import cli
+    monkeypatch.setenv("DOS_HOOK_POSTURE", "gate")
+    _seed_observations(tmp_path, [{"outcome": "deny", "posture": "gate", "surface": "ask"}])
+    cli.cmd_doctor(_doctor_args(tmp_path, as_json=False))
+    out = capsys.readouterr().out
+    assert "enforcement posture gate" in out
+    assert "from env" in out                 # the precedence source is named
+    assert "escalated-to-human" in out       # the split line renders
+
+
+def test_doctor_default_posture_is_block_from_default(monkeypatch, tmp_path, capsys):
+    from dos import cli
+    monkeypatch.delenv("DOS_HOOK_POSTURE", raising=False)
+    cli.cmd_doctor(_doctor_args(tmp_path, as_json=True))
+    enf = json.loads(capsys.readouterr().out)["enforcement"]
+    assert enf["posture"] == "block"
+    assert enf["source"] == "default"


### PR DESCRIPTION
## What this ships (docs/370 Phase C + E)

Builds on the merged Phase-1 `ASK` action + `Posture` seam (#220), taking the
**control-oriented / human-in-the-loop** deployment toward ~98% coverage.

### Phase C — posture-aware observation (`dos doctor` escalated-vs-blocked)

The kernel computes ONE pretool verdict (a deny); the operator's posture chooses
how it is *surfaced*. Phase 1 recorded only the kernel verdict, so the surface
action was rendering-only and invisible to the operator. Now:

- The PreToolUse hook records — **off the BLOCK default** — the `posture` in
  effect and the `surface` action it produced (a deny is `surface=ask` under
  `gate`, `surface=warn` under `observe`) as additive `hook_observation` fields.
  The `outcome` still records the kernel verdict, so the refused/intervened
  denominator stays honest.
- `hook_observation.posture_split` folds the refused pretool records into
  `escalated` / `blocked` / `observed` — a total partition
  (`refused == blocked + escalated + observed`); a posture-blind / pre-Phase-C
  record (no `surface`) counts as `blocked` (the BLOCK-default, behavior-preserving).
- `dos doctor` (text + `--json`) shows the effective posture, **where it came
  from** (env › config › default), and the split — so a `gate` operator sees how
  often DOS handed them a call vs hard-blocked it.
- A default-`block` record is **byte-identical** to a pre-posture one (the parity floor).

### Phase E — `dos init --posture <observe|block|gate>`

Wire the posture at install time so operators can actually turn it on:

- Writes `[enforcement] posture` into `dos.toml`. Choices come from the `Posture`
  enum (the flag never drifts from the seam).
- The value is **merged** into an existing config via a surgical,
  comment-preserving text upsert (`_upsert_enforcement_posture`) — append a
  documented table when absent, replace a value in place when present, idempotent
  on a no-op — so an operator turns `gate` on in a repo that already has a
  `dos.toml`, **without `--force` clobbering the rest**.
- The `gate` confirmation documents the interplay with the host's OWN permission
  settings (the allowlist handles the routine; DOS escalates the adjudicated
  exceptions).
- A bare `dos init` is **byte-for-byte** the pre-Phase-E scaffold (no
  `[enforcement]` table unless asked).

## Tests

`tests/test_posture_observation.py` (14) — the additive record fields, the
`posture_split` partition invariant + back-compat + since-window, the end-to-end
hook recording the surface under each posture (and writing neither field under
the block default), and `dos doctor` surfacing the split.
`tests/test_init_posture.py` (13) — the pure comment-preserving upsert (4 cases +
a lookalike-key guard), the CLI scaffold/merge/idempotency/validation, and the
init→doctor round-trip.

Full non-slow suite green; the Phase-1 `tests/test_hook_ask_posture.py` (45) stays
green. (The 4 WAL/lease failures seen only under the full local Windows run are the
test-documented #125 `%TEMP%` tmp-collision flake — they pass in isolation and
alongside these new tests, and touch no code in this PR.)

## Roadmap remaining (docs/370 §6)

Phase A native per-host ASK · Phase B `HookAction.ALLOW` + the `assist` posture ·
Phase D the decision-inbox round-trip · Phase F Go fast-path parity for `gate`/`observe`.
