### PR TITLE
feat(status): expose fak transcript UUID in dos status (#4116)

### DIFF
--- a/src/dos/cli.py
+++ b/src/dos/cli.py
@@ -4862,6 +4862,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         liveness_verdict=liveness_verdict,
         live_region=region,
         resume_plan=resume_plan,
+        transcript_uuid=__import__("dos.fak_identity", fromlist=["transcript_uuid_for_trace"]).transcript_uuid_for_trace(rid, workspace=Path.cwd()),
     )
 
     # ── read 5 (opt-in): a parent reads its CHILDREN's structural refusals by ──

--- a/src/dos/fak_identity.py
+++ b/src/dos/fak_identity.py
@@ -1,0 +1,26 @@
+"""Read-only join from a DOS run/trace id to fak's transcript UUID ledger."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def transcript_uuid_for_trace(trace_id: str, *, workspace: Path, env: dict[str, str] | None = None) -> str:
+    """Return the latest UUID mapped to *trace_id*, or the honest empty floor."""
+    env = os.environ if env is None else env
+    reg_dir = Path(env.get("FLEET_REG_DIR") or (workspace / "tools" / "_registry"))
+    path = reg_dir / "session_identity.jsonl"
+    found = ""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if str(row.get("trace", "")).strip() == trace_id:
+                    found = str(row.get("uuid", "")).strip()
+    except OSError:
+        return ""
+    return found

--- a/src/dos/status.py
+++ b/src/dos/status.py
@@ -60,6 +60,7 @@ class StatusDigest:
     progress: ProgressView
     region: tuple[str, ...] = ()
     resume: ResumePlan | None = None
+    transcript_uuid: str = ""
     schema: int = STATUS_DIGEST_SCHEMA
 
     def to_dict(self) -> dict:
@@ -76,6 +77,7 @@ class StatusDigest:
             },
             "region": list(self.region),
             "resume": self.resume.to_dict() if self.resume is not None else None,
+            **({"transcript_uuid": self.transcript_uuid} if self.transcript_uuid else {}),
         }
 
 
@@ -86,6 +88,7 @@ def status_digest(
     liveness_verdict: LivenessVerdict,
     live_region: tuple[str, ...] = (),
     resume_plan: ResumePlan | None = None,
+    transcript_uuid: str = "",
 ) -> StatusDigest:
     """Fold the four already-computed verdicts into one digest. PURE.
 
@@ -111,4 +114,5 @@ def status_digest(
         progress=progress,
         region=live_region,
         resume=resume_plan,
+        transcript_uuid=transcript_uuid,
     )

--- a/tests/test_fak_identity.py
+++ b/tests/test_fak_identity.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from dos.fak_identity import transcript_uuid_for_trace
+
+
+def test_transcript_uuid_for_trace_uses_latest_valid_mapping(tmp_path: Path) -> None:
+    reg = tmp_path / "registry"
+    reg.mkdir()
+    (reg / "session_identity.jsonl").write_text(
+        '{"trace":"RID-4116","uuid":"uuid-old"}\n'
+        'torn garbage\n'
+        '{"trace":"other","uuid":"uuid-other"}\n'
+        '{"trace":"RID-4116","uuid":"uuid-new"}\n',
+        encoding="utf-8",
+    )
+    assert transcript_uuid_for_trace("RID-4116", workspace=tmp_path, env={"FLEET_REG_DIR": str(reg)}) == "uuid-new"
+    assert transcript_uuid_for_trace("missing", workspace=tmp_path, env={"FLEET_REG_DIR": str(reg)}) == ""


### PR DESCRIPTION
## Summary
- read fak's append-only session_identity.jsonl at the DOS status boundary
- carry the paired transcript UUID through StatusDigest and dos status --json
- fail closed by omitting the field when no valid mapping exists

## Evidence
- python -m pytest tests/test_fak_identity.py tests/test_status_digest.py tests/test_cmd_status.py -q (22 passed)
- cross-system fixture minted a real RID, wrote the fak identity row shape, and observed transcript_uuid=uuid-cross-4116 from python -m dos.cli status ... --json

Fak-side consumer shipped in anthony-chaudhary/fak@4ab4eed24. Closes the remaining DOS half of anthony-chaudhary/fak#4116.